### PR TITLE
Issue No 5 Fixes.

### DIFF
--- a/Example.App.js
+++ b/Example.App.js
@@ -13,7 +13,11 @@ export default class App extends React.Component {
   };
   onMessage = event => {
     if (event && event.nativeEvent.data) {
-      if (['cancel', 'error', 'expired'].includes(event.nativeEvent.data)) {
+      if (['cancel'].includes(event.nativeEvent.data)) {
+        // do not call this.captchaForm.hide(); function in this condition. Otherwise app will crash.
+        this.setState({ code: event.nativeEvent.data});
+        return;
+      } else if (['error', 'expired'].includes(event.nativeEvent.data)) {
         this.captchaForm.hide();
         this.setState({ code: event.nativeEvent.data});
         return;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { SafeAreaView, StyleSheet, Dimensions } from 'react-native';
+import { SafeAreaView, StyleSheet, Dimensions, Platform } from 'react-native';
 import Modal from 'react-native-modal';
 import Hcaptcha from './Hcaptcha';
 import PropTypes from 'prop-types';
@@ -17,7 +17,9 @@ class ConfirmHcaptcha extends PureComponent {
     const { onMessage } = this.props;
     this.setState({ show: false });
     // In android on hardware back , emits 'cancel' which can be used to hide hCaptcha modal using ref
-    onMessage({ nativeEvent: { data: 'cancel' } });
+    if (Platform.OS === "android") {
+      onMessage({ nativeEvent: { data: 'cancel' } });
+    }
   };
   render() {
     let { show } = this.state;


### PR DESCRIPTION
- In the example file separate the cancel condition to avoid calling the hide function again.
- In the index.js file, cancel event is only needed for Android. Added platform condition to skip sending for iOS to avoid onMessage callback 2 times.