### PR TITLE
#7 Fix UI blink for passive key

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,0 +1,108 @@
+### Generate test app
+
+For `expo` test app
+
+- `cd ..` 
+- `expo init expo-example -t blank`
+- `cd expo-example`
+- `yarn add file:../react-native-hcaptcha`
+- `yarn add react-native-modal`
+- `yarn add react-native-webview`
+- `yarn add expo-constants@^10.0.1`
+- `yarn add @unimodules/core`
+- `yarn add @unimodules/react-native-adapter`
+- `cp ../react-native-hcaptcha/Example.App.js App.js`
+- `yarn android`
+
+For `react-native` test app
+
+- `cd ..` 
+- `react-native init rnexample` or `react-native init rnexample --version 0.63.4` for specific version
+- `cd rnexample`
+- `yarn add file:../react-native-hcaptcha`
+- `yarn add react-native-modal`
+- `yarn add react-native-webview`
+- `yarn add expo-constants@^10.0.1`
+- `yarn add @unimodules/core`
+- `yarn add @unimodules/react-native-adapter`
+- `yarn add react-native-unimodules`
+- `cp ../react-native-hcaptcha/Example.App.js App.js`
+- `yarn android`
+
+
+### Known issues
+
+Problem:
+```
+Error: Unable to resolve module @hcaptcha/react-native-hcaptcha from /Users/camobap/Developers/Projects/hcaptcha/rnexample3/App.js: @hcaptcha/react-native-hcaptcha could not be found within the project or in these directories:
+  node_modules
+```
+
+Solution:
+
+NPM cannot correctly install local moduels. Check
+https://github.com/facebook/react-native/issues/29977 for more details use `yarn`
+
+---
+
+Problem:
+
+`yarn` starts and never finisehd during last module install like this
+```
+...
+[2/4] 🚚  Fetching packages...
+[#####################################################################] 943/944
+```
+
+Solution:
+
+Never create example project inside `react-native-hcaptcha` because it will copy recursively `react-native-hcaptcha` inside examples' `node_modules`
+
+---
+
+Problem:
+
+```
+...
+* What went wrong:
+A problem occurred evaluating project ':unimodules_react-native-adapter'.
+> Project with path ':unimodules-core' could not be found in project ':unimodules_react-native-adapter'.
+```
+
+Solution: https://github.com/unimodules/react-native-unimodules/issues/156
+
+---
+
+Problem:
+
+```
+...
+Starting a Gradle Daemon (subsequent builds will be faster)
+java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7
+```
+
+Solution: make sure that you use Java 1.8
+
+---
+
+Problem:
+
+Gradle finished with error:
+```
+...
+* What went wrong:
+Could not initialize class org.codehaus.groovy.runtime.InvokerHelper
+```
+
+Solution: modify `./android/gradle/wrapper/gradle-wrapper.properties` and update gradle version in `distributionUrl` property
+
+Problem:
+
+Gradle finished with error:
+
+```
+...
+> No toolchains found in the NDK toolchains folder for ABI with prefix: arm-linux-androideabi
+```
+
+Solution: updade `com.android.tools.build:gradle` version in `./android/build.gradle`

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -47,7 +47,7 @@ https://github.com/facebook/react-native/issues/29977 for more details use `yarn
 
 Problem:
 
-`yarn` starts and never finisehd during last module install like this
+`yarn` starts but never finishes during last module install like this
 ```
 ...
 [2/4] 🚚  Fetching packages...

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ class ConfirmHcaptcha extends PureComponent {
     let { show } = this.state;
     let {
       siteKey,
+      passiveSiteKey,
       baseUrl,
       languageCode,
       onMessage,
@@ -39,12 +40,13 @@ class ConfirmHcaptcha extends PureComponent {
         hideModalContentWhileAnimating
         deviceHeight={height}
         deviceWidth={width}
-        style={styles.modal}
+        style={[styles.modal, {display: passiveSiteKey ? 'none' : undefined}]}
         animationIn="fadeIn"
         animationOut="fadeOut"
         onBackdropPress={this.hide}
         onBackButtonPress={this.hide}
         isVisible={show}
+        hasBackdrop={!passiveSiteKey}
       >
         <SafeAreaView style={[styles.wrapper, { backgroundColor }]}>
           <Hcaptcha
@@ -71,7 +73,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 10,
   },
-  modal: { margin: 0 },
+  modal: { margin: 0, display: 'none' },
   wrapper: {
     flex: 1,
     justifyContent: 'center',
@@ -81,6 +83,7 @@ const styles = StyleSheet.create({
 
 ConfirmHcaptcha.propTypes = {
   siteKey: PropTypes.string.isRequired,
+  passiveSiteKey: PropTypes.bool,
   baseUrl: PropTypes.string,
   onMessage: PropTypes.func,
   languageCode: PropTypes.string,
@@ -91,6 +94,7 @@ ConfirmHcaptcha.propTypes = {
 };
 
 ConfirmHcaptcha.defaultProps = {
+  passiveSiteKey: false,
   showLoading: false,
   backgroundColor: 'rgba(0, 0, 0, 0.3)',
   loadingIndicatorColor: null,


### PR DESCRIPTION
1. the fix, proposed in https://github.com/hCaptcha/react-native-hcaptcha/issues/7#issuecomment-996946369 works
2. I have verified the fix with `0.63.4`

### Issues
3. Yesterday I faced with JCenter down issue https://status.gradle.com/
4. Example contains `RangeError: Maximum call stack size exceeded.` loop between `onMessage -> hide -> onMessage -> ...` (screenshot attached). But this error is invisible in production mode only during debug <img src="https://user-images.githubusercontent.com/2169738/149409858-3e31f51c-46d6-409c-8f6b-bda73d98a541.png" width=250 />

### Open question
5. Should I continue the investigation on 4
6. I still have some issues with the 0.66.1 version, @e271828- could you please update your local example to confirm this issue, also I need to know if this important
7. Is there a reason why https://github.com/react-native-modal/react-native-modal used instead `import { Modal } from "react-native";`?
8. I think it makes sense to do some integration testing with `react-native init && yarn add file:..` just to check that compilation works