### PR TITLE
Feature/themes and rqdata

### DIFF
--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -40,70 +40,66 @@ const Hcaptcha = ({
   backgroundColor,
 }) => {
   const generateTheWebViewContent = useMemo(
-    () =>
-      `<!DOCTYPE html>
-			<html>
-			<head> 
-				<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-				<meta http-equiv="X-UA-Compatible" content="ie=edge"> 
-				<script src="https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=${
-          languageCode || 'en'
-        }&host=${
-        siteKey || 'missing-sitekey'
-      }.react-native.hcaptcha.com" async defer></script> 
-				<script type="text/javascript"> 
-				var onloadCallback = function() {
-			        try {
-			          console.log("challenge onload starting");
-			          hcaptcha.render("submit", {
-			            sitekey: "${siteKey || ''}",
-			            size: "invisible",
-			            "callback": onDataCallback,
-			            "close-callback": onCancel,
-			            "open-callback": onOpen,
-			            "expired-callback": onDataExpiredCallback,
-			            "chalexpired-callback": onChalExpiredCallback,
-			            "error-callback": onDataErrorCallback
-			          });
-			          // have loaded by this point; render is sync.
-			          console.log("challenge render complete");
-			        } catch (e) {
-			          console.log("challenge failed to render");
-					  window.ReactNativeWebView.postMessage("error");
-			        }
+    () => 
+     `<!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <script src="https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=${languageCode || 'en'}&host=${siteKey || 'missing-sitekey'}.react-native.hcaptcha.com" async defer>
+        </script>
+        <script type="text/javascript">
+          var onloadCallback = function() {
+            try {
+              console.log("challenge onload starting");
+              hcaptcha.render("submit", {
+                sitekey: "${siteKey || ''}",
+                size: "invisible",
+                callback: onDataCallback,
+                "close-callback": onCancel,
+                "open-callback": onOpen,
+                "expired-callback": onDataExpiredCallback,
+                "chalexpired-callback": onChalExpiredCallback,
+                "error-callback": onDataErrorCallback
+              });
+              // have loaded by this point; render is sync.
+              console.log("challenge render complete");
+            } catch (e) {
+              console.log("challenge failed to render");
+              window.ReactNativeWebView.postMessage("error");
+            }
 
-			        try {
-			          console.log("showing challenge");
-			          hcaptcha.execute();
-			        } catch (e) {
-			          console.log("failed to show challenge");
-					  window.ReactNativeWebView.postMessage("error");
-			        }
-
-				};  
-				var onDataCallback = function(response) {
-					window.ReactNativeWebView.postMessage(response);  
-				};  
-				var onCancel = function() {
-					window.ReactNativeWebView.postMessage("cancel"); 
-				}
-				var onOpen = function() {
-					// NOTE: disabled for simplicity.
-					// window.ReactNativeWebView.postMessage("open");
-					console.log("challenge opened");
-				}
-				var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("expired"); };
-				var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("cancel"); };
-				var onDataErrorCallback = function(error) {
-					console.log("challenge error callback fired");
-					window.ReactNativeWebView.postMessage("error");
-				}
-				</script>
-			</head>
-			<body style="background-color: ${backgroundColor};"> 
-			    <div id="submit"></div>
-			</body>
-	    </html>`,
+            try {
+              console.log("showing challenge");
+              hcaptcha.execute();
+            } catch (e) {
+              console.log("failed to show challenge");
+              window.ReactNativeWebView.postMessage("error");
+            }
+          };
+          var onDataCallback = function(response) {
+            window.ReactNativeWebView.postMessage(response);
+          };
+          var onCancel = function() {
+            window.ReactNativeWebView.postMessage("cancel");
+          }
+          var onOpen = function() {
+            // NOTE: disabled for simplicity.
+            // window.ReactNativeWebView.postMessage("open");
+            console.log("challenge opened");
+          }
+          var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("expired"); };
+          var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("cancel"); };
+          var onDataErrorCallback = function(error) {
+            console.log("challenge error callback fired");
+            window.ReactNativeWebView.postMessage("error");
+          }
+        </script>
+      </head>
+      <body style="background-color: ${backgroundColor};">
+        <div id="submit"></div>
+      </body>
+      </html>`,
     [siteKey, languageCode]
   );
 

--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -40,6 +40,7 @@ const buildHcaptchaApiUrl = (siteKey, languageCode, theme) => {
  * @param {*} loadingIndicatorColor: color for the ActivityIndicator
  * @param {*} backgroundColor: backgroundColor which can be injected into HTML to alter css backdrop colour
  * @param {*} theme: can be 'light', 'dark', 'contrast' or custom theme object
+ * @param {*} rqdata: custom supplied challenge data
  */
 const Hcaptcha = ({
   onMessage,
@@ -52,11 +53,16 @@ const Hcaptcha = ({
   loadingIndicatorColor,
   backgroundColor,
   theme,
+  rqdata,
 }) => {
   const apiUrl = buildHcaptchaApiUrl(siteKey, languageCode, theme);
 
   if (theme && typeof theme === 'string') {
     theme = `"${theme}"`;
+  }
+
+  if (rqdata && typeof rqdata === 'string') {
+    rqdata = `"${rqdata}"`;
   }
 
   const generateTheWebViewContent = useMemo(
@@ -81,7 +87,7 @@ const Hcaptcha = ({
             }
             try {
               console.log("showing challenge");
-              hcaptcha.execute();
+              hcaptcha.execute(getExecuteOpts());
             } catch (e) {
               console.log("failed to show challenge");
               window.ReactNativeWebView.postMessage("error");
@@ -104,7 +110,7 @@ const Hcaptcha = ({
             console.log("challenge error callback fired");
             window.ReactNativeWebView.postMessage("error");
           };
-          var getRenderConfig = function(siteKey, theme) {
+          const getRenderConfig = function(siteKey, theme) {
             var config = {
               sitekey: siteKey,
               size: "invisible",
@@ -119,6 +125,14 @@ const Hcaptcha = ({
               config.theme = theme;
             }
             return config;
+          };
+          const getExecuteOpts = function() {
+            var opts;
+            const rqdata = ${rqdata};
+            if (rqdata) {
+              opts = {"rqdata": rqdata};
+            }
+            return opts;
           };
         </script>
       </head>

--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -40,7 +40,7 @@ const buildHcaptchaApiUrl = (siteKey, languageCode, theme) => {
  * @param {*} loadingIndicatorColor: color for the ActivityIndicator
  * @param {*} backgroundColor: backgroundColor which can be injected into HTML to alter css backdrop colour
  * @param {*} theme: can be 'light', 'dark', 'contrast' or custom theme object
- * @param {*} rqdata: custom supplied challenge data
+ * @param {*} rqdata: see Enterprise docs
  */
 const Hcaptcha = ({
   onMessage,

--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -42,7 +42,7 @@ const Hcaptcha = ({
   theme,
 }) => {
   const customTheme = typeof theme === 'object';
-  if (!customTheme) {
+  if (theme && !customTheme) {
     theme = `"${theme}"`;
   }
 
@@ -90,18 +90,18 @@ const Hcaptcha = ({
           };
           var onCancel = function() {
             window.ReactNativeWebView.postMessage("cancel");
-          }
+          };
           var onOpen = function() {
             // NOTE: disabled for simplicity.
             // window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
-          }
+          };
           var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("expired"); };
           var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage("cancel"); };
           var onDataErrorCallback = function(error) {
             console.log("challenge error callback fired");
             window.ReactNativeWebView.postMessage("error");
-          }
+          };
         </script>
       </head>
       <body style="background-color: ${backgroundColor};">

--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -27,6 +27,7 @@ const patchPostMessageJsCode = `(${String(function () {
  * @param {*} showLoading: loading indicator for webview till hCaptcha web content loads
  * @param {*} loadingIndicatorColor: color for the ActivityIndicator
  * @param {*} backgroundColor: backgroundColor which can be injected into HTML to alter css backdrop colour
+ * @param {*} theme: can be 'light', 'dark', 'contrast' or custom theme object
  */
 const Hcaptcha = ({
   onMessage,
@@ -35,19 +36,25 @@ const Hcaptcha = ({
   url,
   languageCode,
   cancelButtonText = 'Cancel',
-  showLoading = false,
-  loadingIndicatorColor = null,
+  showLoading,
+  loadingIndicatorColor,
   backgroundColor,
+  theme,
 }) => {
+  const customTheme = typeof theme === 'object';
+  if (!customTheme) {
+    theme = `"${theme}"`;
+  }
+
   const generateTheWebViewContent = useMemo(
     () => 
      `<!DOCTYPE html>
       <html>
       <head>
-        <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
-        <script src="https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=${languageCode || 'en'}&host=${siteKey || 'missing-sitekey'}.react-native.hcaptcha.com" async defer>
-        </script>
+        <script src="https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=${languageCode || 'en'}&host=${siteKey || 'missing-sitekey'}.react-native.hcaptcha.com&custom=${customTheme}" async defer></script>
         <script type="text/javascript">
           var onloadCallback = function() {
             try {
@@ -55,6 +62,7 @@ const Hcaptcha = ({
               hcaptcha.render("submit", {
                 sitekey: "${siteKey || ''}",
                 size: "invisible",
+                theme: ${theme},
                 callback: onDataCallback,
                 "close-callback": onCancel,
                 "open-callback": onOpen,
@@ -100,7 +108,7 @@ const Hcaptcha = ({
         <div id="submit"></div>
       </body>
       </html>`,
-    [siteKey, languageCode]
+    [siteKey, languageCode, theme]
   );
 
   // This shows ActivityIndicator till webview loads hCaptcha images

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -120,4 +120,4 @@ ERROR    Invariant Violation: No callback found with cbID xxxxx and callID yyyyy
 
 Solution: delete `node_modules` in `react-native-hcaptcha`.
 
-Issue related to missmatch `react-native` versions in a test app and `react-native-hcaptcha`
+This issue is related to mismatched `react-native` versions in the test app vs. `react-native-hcaptcha`

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -6,11 +6,7 @@ For `expo` test app
 - `expo init expo-example -t blank`
 - `cd expo-example`
 - `yarn add file:../react-native-hcaptcha`
-- `yarn add react-native-modal`
-- `yarn add react-native-webview`
-- `yarn add expo-constants@^10.0.1`
-- `yarn add @unimodules/core`
-- `yarn add @unimodules/react-native-adapter`
+- `yarn add react-native-modal react-native-webview expo-constants@^10.0.1 @unimodules/core @unimodules/react-native-adapter`
 - `cp ../react-native-hcaptcha/Example.App.js App.js`
 - `yarn android`
 
@@ -20,14 +16,14 @@ For `react-native` test app
 - `react-native init rnexample` or `react-native init rnexample --version 0.63.4` for specific version
 - `cd rnexample`
 - `yarn add file:../react-native-hcaptcha`
-- `yarn add react-native-modal`
-- `yarn add react-native-webview`
-- `yarn add expo-constants@^10.0.1`
-- `yarn add @unimodules/core`
-- `yarn add @unimodules/react-native-adapter`
-- `yarn add react-native-unimodules`
+- `yarn add react-native-modal react-native-webview expo-constants@^10.0.1 @unimodules/core @unimodules/react-native-adapter react-native-unimodules`
 - `cp ../react-native-hcaptcha/Example.App.js App.js`
 - `yarn android`
+
+For iOS instead the last step do:
+
+- `pushd ios; pod install; popd`
+- `yarn ios`
 
 
 ### Known issues
@@ -106,3 +102,22 @@ Gradle finished with error:
 ```
 
 Solution: updade `com.android.tools.build:gradle` version in `./android/build.gradle`
+
+---
+
+Problem:
+
+Infinite error logs like:
+
+```
+WARN     Sending `didSendNetworkData` with no listeners registered.
+WARN     Sending `didReceiveNetworkResponse` with no listeners registered.
+WARN     Sending `didReceiveNetworkData` with no listeners registered.
+WARN     Sending `didCompleteNetworkResponse` with no listeners registered.
+ERROR    Invariant Violation: No callback found with cbID xxxxx and callID yyyyy for module <unknown>. Args: '[zzzz]'
+
+```
+
+Solution: delete `node_modules` in `react-native-hcaptcha`.
+
+Issue related to missmatch `react-native` versions in a test app and `react-native-hcaptcha`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ languages and their codes can be found at [this link](https://docs.hcaptcha.com/
 - **`loadingIndicatorColor`** _(String)_ - color for the ActivityIndicator
 - **`backgroundColor`** _(String)_ - background color used in HTML
 - **`theme`** _(String|Object)_ - `theme` parameter can be 'light', 'dark', 'contrast' or custom theme object (see Enterprise docs)
-- **`rqdata`** _(String)_ - custom supplied challenge data (see Enterprise docs)
+- **`rqdata`** _(String)_ - see Enterprise docs
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ languages and their codes can be found at [this link](https://docs.hcaptcha.com/
 - **`showLoading`** _(Bool)_ - show loading indicator for webview till hCaptcha web content loads?
 - **`loadingIndicatorColor`** _(String)_ - color for the ActivityIndicator
 - **`backgroundColor`** _(String)_ - background color used in HTML
-- **`theme`** _(String|Object)_ - theme for hcaptcha can be 'light', 'dark', 'contrast' or custom theme object (see Enterprise docs)
+- **`theme`** _(String|Object)_ - `theme` parameter can be 'light', 'dark', 'contrast' or custom theme object (see Enterprise docs)
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ languages and their codes can be found at [this link](https://docs.hcaptcha.com/
 - **`loadingIndicatorColor`** _(String)_ - color for the ActivityIndicator
 - **`backgroundColor`** _(String)_ - background color used in HTML
 - **`theme`** _(String|Object)_ - `theme` parameter can be 'light', 'dark', 'contrast' or custom theme object (see Enterprise docs)
+- **`rqdata`** _(String)_ - custom supplied challenge data (see Enterprise docs)
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ languages and their codes can be found at [this link](https://docs.hcaptcha.com/
 - **`showLoading`** _(Bool)_ - show loading indicator for webview till hCaptcha web content loads?
 - **`loadingIndicatorColor`** _(String)_ - color for the ActivityIndicator
 - **`backgroundColor`** _(String)_ - background color used in HTML
-
+- **`theme`** _(String|Object)_ - theme for hcaptcha can be 'light', 'dark', 'contrast' or custom theme object (see Enterprise docs)
 
 ## Status
 

--- a/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
@@ -67,64 +67,65 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
         Object {
           "baseUrl": "https://hcaptcha.com",
           "html": "<!DOCTYPE html>
-			<html>
-			<head> 
-				<meta charset=\\"UTF-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
-				<meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\"> 
-				<script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com\\" async defer></script> 
-				<script type=\\"text/javascript\\"> 
-				var onloadCallback = function() {
-			        try {
-			          console.log(\\"challenge onload starting\\");
-			          hcaptcha.render(\\"submit\\", {
-			            sitekey: \\"00000000-0000-0000-0000-000000000000\\",
-			            size: \\"invisible\\",
-			            \\"callback\\": onDataCallback,
-			            \\"close-callback\\": onCancel,
-			            \\"open-callback\\": onOpen,
-			            \\"expired-callback\\": onDataExpiredCallback,
-			            \\"chalexpired-callback\\": onChalExpiredCallback,
-			            \\"error-callback\\": onDataErrorCallback
-			          });
-			          // have loaded by this point; render is sync.
-			          console.log(\\"challenge render complete\\");
-			        } catch (e) {
-			          console.log(\\"challenge failed to render\\");
-					  window.ReactNativeWebView.postMessage(\\"error\\");
-			        }
+      <html>
+      <head>
+        <meta charset=\\"UTF-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
+        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&custom=false\\" async defer></script>
+        <script type=\\"text/javascript\\">
+          var onloadCallback = function() {
+            try {
+              console.log(\\"challenge onload starting\\");
+              hcaptcha.render(\\"submit\\", {
+                sitekey: \\"00000000-0000-0000-0000-000000000000\\",
+                size: \\"invisible\\",
+                theme: \\"light\\",
+                callback: onDataCallback,
+                \\"close-callback\\": onCancel,
+                \\"open-callback\\": onOpen,
+                \\"expired-callback\\": onDataExpiredCallback,
+                \\"chalexpired-callback\\": onChalExpiredCallback,
+                \\"error-callback\\": onDataErrorCallback
+              });
+              // have loaded by this point; render is sync.
+              console.log(\\"challenge render complete\\");
+            } catch (e) {
+              console.log(\\"challenge failed to render\\");
+              window.ReactNativeWebView.postMessage(\\"error\\");
+            }
 
-			        try {
-			          console.log(\\"showing challenge\\");
-			          hcaptcha.execute();
-			        } catch (e) {
-			          console.log(\\"failed to show challenge\\");
-					  window.ReactNativeWebView.postMessage(\\"error\\");
-			        }
-
-				};  
-				var onDataCallback = function(response) {
-					window.ReactNativeWebView.postMessage(response);  
-				};  
-				var onCancel = function() {
-					window.ReactNativeWebView.postMessage(\\"cancel\\"); 
-				}
-				var onOpen = function() {
-					// NOTE: disabled for simplicity.
-					// window.ReactNativeWebView.postMessage(\\"open\\");
-					console.log(\\"challenge opened\\");
-				}
-				var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
-				var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
-				var onDataErrorCallback = function(error) {
-					console.log(\\"challenge error callback fired\\");
-					window.ReactNativeWebView.postMessage(\\"error\\");
-				}
-				</script>
-			</head>
-			<body style=\\"background-color: rgba(0, 0, 0, 0.3);\\"> 
-			    <div id=\\"submit\\"></div>
-			</body>
-	    </html>",
+            try {
+              console.log(\\"showing challenge\\");
+              hcaptcha.execute();
+            } catch (e) {
+              console.log(\\"failed to show challenge\\");
+              window.ReactNativeWebView.postMessage(\\"error\\");
+            }
+          };
+          var onDataCallback = function(response) {
+            window.ReactNativeWebView.postMessage(response);
+          };
+          var onCancel = function() {
+            window.ReactNativeWebView.postMessage(\\"cancel\\");
+          };
+          var onOpen = function() {
+            // NOTE: disabled for simplicity.
+            // window.ReactNativeWebView.postMessage(\\"open\\");
+            console.log(\\"challenge opened\\");
+          };
+          var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
+          var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
+          var onDataErrorCallback = function(error) {
+            console.log(\\"challenge error callback fired\\");
+            window.ReactNativeWebView.postMessage(\\"error\\");
+          };
+        </script>
+      </head>
+      <body style=\\"background-color: rgba(0, 0, 0, 0.3);\\">
+        <div id=\\"submit\\"></div>
+      </body>
+      </html>",
         }
       }
       startInLoadingState={false}

--- a/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
@@ -72,29 +72,18 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
         <meta charset=\\"UTF-8\\">
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
-        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&custom=false\\" async defer></script>
+        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&hl=en\\" async defer></script>
         <script type=\\"text/javascript\\">
           var onloadCallback = function() {
             try {
               console.log(\\"challenge onload starting\\");
-              hcaptcha.render(\\"submit\\", {
-                sitekey: \\"00000000-0000-0000-0000-000000000000\\",
-                size: \\"invisible\\",
-                theme: \\"light\\",
-                callback: onDataCallback,
-                \\"close-callback\\": onCancel,
-                \\"open-callback\\": onOpen,
-                \\"expired-callback\\": onDataExpiredCallback,
-                \\"chalexpired-callback\\": onChalExpiredCallback,
-                \\"error-callback\\": onDataErrorCallback
-              });
+              hcaptcha.render(\\"submit\\", getRenderConfig(\\"00000000-0000-0000-0000-000000000000\\", \\"light\\"));
               // have loaded by this point; render is sync.
               console.log(\\"challenge render complete\\");
             } catch (e) {
               console.log(\\"challenge failed to render\\");
               window.ReactNativeWebView.postMessage(\\"error\\");
             }
-
             try {
               console.log(\\"showing challenge\\");
               hcaptcha.execute();
@@ -114,11 +103,27 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
             // window.ReactNativeWebView.postMessage(\\"open\\");
             console.log(\\"challenge opened\\");
           };
-          var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
-          var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
+          var onDataExpiredCallback = function(error) { window.ReactNativeWebView.postMessage(\\"expired\\"); };
+          var onChalExpiredCallback = function(error) { window.ReactNativeWebView.postMessage(\\"cancel\\"); };
           var onDataErrorCallback = function(error) {
             console.log(\\"challenge error callback fired\\");
             window.ReactNativeWebView.postMessage(\\"error\\");
+          };
+          var getRenderConfig = function(siteKey, theme) {
+            var config = {
+              sitekey: siteKey,
+              size: \\"invisible\\",
+              callback: onDataCallback,
+              \\"close-callback\\": onCancel,
+              \\"open-callback\\": onOpen,
+              \\"expired-callback\\": onDataExpiredCallback,
+              \\"chalexpired-callback\\": onChalExpiredCallback,
+              \\"error-callback\\": onDataErrorCallback
+            };
+            if (theme) {
+              config.theme = theme;
+            }
+            return config;
           };
         </script>
       </head>

--- a/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
@@ -86,7 +86,7 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
             }
             try {
               console.log(\\"showing challenge\\");
-              hcaptcha.execute();
+              hcaptcha.execute(getExecuteOpts());
             } catch (e) {
               console.log(\\"failed to show challenge\\");
               window.ReactNativeWebView.postMessage(\\"error\\");
@@ -109,7 +109,7 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
             console.log(\\"challenge error callback fired\\");
             window.ReactNativeWebView.postMessage(\\"error\\");
           };
-          var getRenderConfig = function(siteKey, theme) {
+          const getRenderConfig = function(siteKey, theme) {
             var config = {
               sitekey: siteKey,
               size: \\"invisible\\",
@@ -124,6 +124,14 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
               config.theme = theme;
             }
             return config;
+          };
+          const getExecuteOpts = function() {
+            var opts;
+            const rqdata = null;
+            if (rqdata) {
+              opts = {\\"rqdata\\": rqdata};
+            }
+            return opts;
           };
         </script>
       </head>

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -48,7 +48,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
             }
             try {
               console.log(\\"showing challenge\\");
-              hcaptcha.execute();
+              hcaptcha.execute(getExecuteOpts());
             } catch (e) {
               console.log(\\"failed to show challenge\\");
               window.ReactNativeWebView.postMessage(\\"error\\");
@@ -71,7 +71,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
             console.log(\\"challenge error callback fired\\");
             window.ReactNativeWebView.postMessage(\\"error\\");
           };
-          var getRenderConfig = function(siteKey, theme) {
+          const getRenderConfig = function(siteKey, theme) {
             var config = {
               sitekey: siteKey,
               size: \\"invisible\\",
@@ -86,6 +86,14 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
               config.theme = theme;
             }
             return config;
+          };
+          const getExecuteOpts = function() {
+            var opts;
+            const rqdata = undefined;
+            if (rqdata) {
+              opts = {\\"rqdata\\": rqdata};
+            }
+            return opts;
           };
         </script>
       </head>

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -90,7 +90,6 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
       </html>",
     }
   }
-  startInLoadingState={false}
   style={
     Array [
       Object {

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -29,64 +29,65 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
     Object {
       "baseUrl": "https://hcaptcha.com",
       "html": "<!DOCTYPE html>
-			<html>
-			<head> 
-				<meta charset=\\"UTF-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
-				<meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\"> 
-				<script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=missing-sitekey.react-native.hcaptcha.com\\" async defer></script> 
-				<script type=\\"text/javascript\\"> 
-				var onloadCallback = function() {
-			        try {
-			          console.log(\\"challenge onload starting\\");
-			          hcaptcha.render(\\"submit\\", {
-			            sitekey: \\"\\",
-			            size: \\"invisible\\",
-			            \\"callback\\": onDataCallback,
-			            \\"close-callback\\": onCancel,
-			            \\"open-callback\\": onOpen,
-			            \\"expired-callback\\": onDataExpiredCallback,
-			            \\"chalexpired-callback\\": onChalExpiredCallback,
-			            \\"error-callback\\": onDataErrorCallback
-			          });
-			          // have loaded by this point; render is sync.
-			          console.log(\\"challenge render complete\\");
-			        } catch (e) {
-			          console.log(\\"challenge failed to render\\");
-					  window.ReactNativeWebView.postMessage(\\"error\\");
-			        }
+      <html>
+      <head>
+        <meta charset=\\"UTF-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
+        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=missing-sitekey.react-native.hcaptcha.com&custom=false\\" async defer></script>
+        <script type=\\"text/javascript\\">
+          var onloadCallback = function() {
+            try {
+              console.log(\\"challenge onload starting\\");
+              hcaptcha.render(\\"submit\\", {
+                sitekey: \\"\\",
+                size: \\"invisible\\",
+                theme: undefined,
+                callback: onDataCallback,
+                \\"close-callback\\": onCancel,
+                \\"open-callback\\": onOpen,
+                \\"expired-callback\\": onDataExpiredCallback,
+                \\"chalexpired-callback\\": onChalExpiredCallback,
+                \\"error-callback\\": onDataErrorCallback
+              });
+              // have loaded by this point; render is sync.
+              console.log(\\"challenge render complete\\");
+            } catch (e) {
+              console.log(\\"challenge failed to render\\");
+              window.ReactNativeWebView.postMessage(\\"error\\");
+            }
 
-			        try {
-			          console.log(\\"showing challenge\\");
-			          hcaptcha.execute();
-			        } catch (e) {
-			          console.log(\\"failed to show challenge\\");
-					  window.ReactNativeWebView.postMessage(\\"error\\");
-			        }
-
-				};  
-				var onDataCallback = function(response) {
-					window.ReactNativeWebView.postMessage(response);  
-				};  
-				var onCancel = function() {
-					window.ReactNativeWebView.postMessage(\\"cancel\\"); 
-				}
-				var onOpen = function() {
-					// NOTE: disabled for simplicity.
-					// window.ReactNativeWebView.postMessage(\\"open\\");
-					console.log(\\"challenge opened\\");
-				}
-				var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
-				var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
-				var onDataErrorCallback = function(error) {
-					console.log(\\"challenge error callback fired\\");
-					window.ReactNativeWebView.postMessage(\\"error\\");
-				}
-				</script>
-			</head>
-			<body style=\\"background-color: undefined;\\"> 
-			    <div id=\\"submit\\"></div>
-			</body>
-	    </html>",
+            try {
+              console.log(\\"showing challenge\\");
+              hcaptcha.execute();
+            } catch (e) {
+              console.log(\\"failed to show challenge\\");
+              window.ReactNativeWebView.postMessage(\\"error\\");
+            }
+          };
+          var onDataCallback = function(response) {
+            window.ReactNativeWebView.postMessage(response);
+          };
+          var onCancel = function() {
+            window.ReactNativeWebView.postMessage(\\"cancel\\");
+          };
+          var onOpen = function() {
+            // NOTE: disabled for simplicity.
+            // window.ReactNativeWebView.postMessage(\\"open\\");
+            console.log(\\"challenge opened\\");
+          };
+          var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
+          var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
+          var onDataErrorCallback = function(error) {
+            console.log(\\"challenge error callback fired\\");
+            window.ReactNativeWebView.postMessage(\\"error\\");
+          };
+        </script>
+      </head>
+      <body style=\\"background-color: undefined;\\">
+        <div id=\\"submit\\"></div>
+      </body>
+      </html>",
     }
   }
   startInLoadingState={false}

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -34,29 +34,18 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
         <meta charset=\\"UTF-8\\">
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
-        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&hl=en&host=missing-sitekey.react-native.hcaptcha.com&custom=false\\" async defer></script>
+        <script src=\\"https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&host=missing-sitekey.react-native.hcaptcha.com\\" async defer></script>
         <script type=\\"text/javascript\\">
           var onloadCallback = function() {
             try {
               console.log(\\"challenge onload starting\\");
-              hcaptcha.render(\\"submit\\", {
-                sitekey: \\"\\",
-                size: \\"invisible\\",
-                theme: undefined,
-                callback: onDataCallback,
-                \\"close-callback\\": onCancel,
-                \\"open-callback\\": onOpen,
-                \\"expired-callback\\": onDataExpiredCallback,
-                \\"chalexpired-callback\\": onChalExpiredCallback,
-                \\"error-callback\\": onDataErrorCallback
-              });
+              hcaptcha.render(\\"submit\\", getRenderConfig(\\"\\", undefined));
               // have loaded by this point; render is sync.
               console.log(\\"challenge render complete\\");
             } catch (e) {
               console.log(\\"challenge failed to render\\");
               window.ReactNativeWebView.postMessage(\\"error\\");
             }
-
             try {
               console.log(\\"showing challenge\\");
               hcaptcha.execute();
@@ -76,11 +65,27 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
             // window.ReactNativeWebView.postMessage(\\"open\\");
             console.log(\\"challenge opened\\");
           };
-          var onDataExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"expired\\"); };
-          var onChalExpiredCallback = function(error) {  window.ReactNativeWebView.postMessage(\\"cancel\\"); };
+          var onDataExpiredCallback = function(error) { window.ReactNativeWebView.postMessage(\\"expired\\"); };
+          var onChalExpiredCallback = function(error) { window.ReactNativeWebView.postMessage(\\"cancel\\"); };
           var onDataErrorCallback = function(error) {
             console.log(\\"challenge error callback fired\\");
             window.ReactNativeWebView.postMessage(\\"error\\");
+          };
+          var getRenderConfig = function(siteKey, theme) {
+            var config = {
+              sitekey: siteKey,
+              size: \\"invisible\\",
+              callback: onDataCallback,
+              \\"close-callback\\": onCancel,
+              \\"open-callback\\": onOpen,
+              \\"expired-callback\\": onDataExpiredCallback,
+              \\"chalexpired-callback\\": onChalExpiredCallback,
+              \\"error-callback\\": onDataErrorCallback
+            };
+            if (theme) {
+              config.theme = theme;
+            }
+            return config;
           };
         </script>
       </head>

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class ConfirmHcaptcha extends PureComponent {
       backgroundColor,
       loadingIndicatorColor,
       theme,
+      rqdata,
     } = this.props;
     return (
       <Modal
@@ -60,6 +61,7 @@ class ConfirmHcaptcha extends PureComponent {
             loadingIndicatorColor={loadingIndicatorColor}
             backgroundColor={backgroundColor}
             theme={theme}
+            rqdata={rqdata}
           />
         </SafeAreaView>
       </Modal>
@@ -93,6 +95,8 @@ ConfirmHcaptcha.propTypes = {
   backgroundColor: PropTypes.string,
   showLoading: PropTypes.bool,
   loadingIndicatorColor: PropTypes.string,
+  theme: PropTypes.string,
+  rqdata: PropTypes.string,
 };
 
 ConfirmHcaptcha.defaultProps = {
@@ -101,6 +105,7 @@ ConfirmHcaptcha.defaultProps = {
   backgroundColor: 'rgba(0, 0, 0, 0.3)',
   loadingIndicatorColor: null,
   theme: 'light',
+  rqdata: null,
 };
 
 export default ConfirmHcaptcha;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class ConfirmHcaptcha extends PureComponent {
       showLoading,
       backgroundColor,
       loadingIndicatorColor,
+      theme,
     } = this.props;
     return (
       <Modal
@@ -58,6 +59,7 @@ class ConfirmHcaptcha extends PureComponent {
             showLoading={showLoading}
             loadingIndicatorColor={loadingIndicatorColor}
             backgroundColor={backgroundColor}
+            theme={theme}
           />
         </SafeAreaView>
       </Modal>
@@ -98,6 +100,7 @@ ConfirmHcaptcha.defaultProps = {
   showLoading: false,
   backgroundColor: 'rgba(0, 0, 0, 0.3)',
   loadingIndicatorColor: null,
+  theme: 'light',
 };
 
 export default ConfirmHcaptcha;


### PR DESCRIPTION
 - #10 

### Open questions
 - I suppose that `custom=false` param in URL will be handled correctly
 - `react-native-webview` has really poor error handling. In case of malformed HTML [`onError`](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#onerror) not triggered. Probably because of this we don't have it at all. But it will be really useful to get some errors in `onMessage`. I have tried this:
    ```
   <WebView
     ...
     onError={(event) => {
        event.nativeEvent.data = 'error';
        onMessage(event);
      }}
     ...
   />
    ```