### PR TITLE
Fix TypeError: replaceAll is not a function

### DIFF
--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -75,8 +75,8 @@ const Hcaptcha = ({
       try {
         const {major, minor, patch} = ReactNativeVersion.version;
         result.push(`rnver_${major}_${minor}_${patch}`);
-        result.push('sdk_' + hcaptchaPackage.version.replaceAll('.', '_'));
         result.push('dep_' + md5(Object.keys(global).join('')));
+        result.push('sdk_' + hcaptchaPackage.version.toString().replace(/\./g, '_'));
       } catch (e) {
         console.log(e);
       } finally {


### PR DESCRIPTION
Fix for:

```
 [TypeError: _package.default.version.replaceAll is not a function. (In '_package.default.version.replaceAll('.', '_')', '_package.default.version.replaceAll' is undefined)]
```