### PR TITLE
removes useless cancelButtonText prop

### DIFF
--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -39,7 +39,6 @@ const buildHcaptchaApiUrl = (siteKey, languageCode, theme) => {
  * @param {*} style: custom style
  * @param {*} url: base url
  * @param {*} languageCode: can be found at https://docs.hcaptcha.com/languages
- * @param {*} cancelButtonText: title of cancel button
  * @param {*} showLoading: loading indicator for webview till hCaptcha web content loads
  * @param {*} loadingIndicatorColor: color for the ActivityIndicator
  * @param {*} backgroundColor: backgroundColor which can be injected into HTML to alter css backdrop colour
@@ -52,7 +51,6 @@ const Hcaptcha = ({
   style,
   url,
   languageCode,
-  cancelButtonText = 'Cancel',
   showLoading,
   loadingIndicatorColor,
   backgroundColor,

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ class ConfirmHcaptcha extends PureComponent {
       baseUrl,
       languageCode,
       onMessage,
-      cancelButtonText,
       showLoading,
       backgroundColor,
       loadingIndicatorColor,
@@ -55,7 +54,6 @@ class ConfirmHcaptcha extends PureComponent {
             siteKey={siteKey}
             onMessage={onMessage}
             languageCode={languageCode}
-            cancelButtonText={cancelButtonText}
             showLoading={showLoading}
             loadingIndicatorColor={loadingIndicatorColor}
             backgroundColor={backgroundColor}
@@ -90,7 +88,6 @@ ConfirmHcaptcha.propTypes = {
   baseUrl: PropTypes.string,
   onMessage: PropTypes.func,
   languageCode: PropTypes.string,
-  cancelButtonText: PropTypes.string,
   backgroundColor: PropTypes.string,
   showLoading: PropTypes.bool,
   loadingIndicatorColor: PropTypes.string,


### PR DESCRIPTION
Removes the `cancelButtonText` prop that has been deleted since https://github.com/hCaptcha/react-native-hcaptcha/commit/c7a930beb1dd6c04e80168a17505bdb032b78934