### PR TITLE
feat: Add the hasBackdrop property

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Otherwise, you should pass in the preferred device locale, e.g. fetched from `ge
 | style _(inline component only)_ | ViewStyle (see [here](https://reactnative.dev/docs/view-style-props)) | The webview style |
 | baseUrl _(modal component only)_ | string | The url domain defined on your hCaptcha. You generally will not need to change this. |
 | passiveSiteKey _(modal component only)_ | boolean | Indicates whether the passive mode is enabled; when true, the modal won't be shown at all |
+| hasBackdrop _(modal component only)_ | boolean | To hide the modal backDrop; when true, the backDrop modal won’t be displayed |
 
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Otherwise, you should pass in the preferred device locale, e.g. fetched from `ge
 | style _(inline component only)_ | ViewStyle (see [here](https://reactnative.dev/docs/view-style-props)) | The webview style |
 | baseUrl _(modal component only)_ | string | The url domain defined on your hCaptcha. You generally will not need to change this. |
 | passiveSiteKey _(modal component only)_ | boolean | Indicates whether the passive mode is enabled; when true, the modal won't be shown at all |
-| hasBackdrop _(modal component only)_ | boolean | To hide the modal backDrop; when true, the backDrop modal won’t be displayed |
+| hasBackdrop _(modal component only)_ | boolean | Defines if the modal backdrop is shown (true by default) |
 
 
 ## Status

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ConfirmHcaptcha extends PureComponent {
         onBackdropPress={() => this.hide('backdrop')}
         onBackButtonPress={() => this.hide('back_button')}
         isVisible={show}
-        hasBackdrop={hasBackdrop}
+        hasBackdrop={!passiveSiteKey && hasBackdrop}
         coverScreen={!passiveSiteKey}
       >
         <SafeAreaView style={[styles.wrapper, { backgroundColor }]}>

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class ConfirmHcaptcha extends PureComponent {
       assethost,
       imghost,
       host,
+      hasBackdrop,
     } = this.props;
 
     return (
@@ -55,7 +56,7 @@ class ConfirmHcaptcha extends PureComponent {
         onBackdropPress={() => this.hide('backdrop')}
         onBackButtonPress={() => this.hide('back_button')}
         isVisible={show}
-        hasBackdrop={!passiveSiteKey}
+        hasBackdrop={hasBackdrop}
         coverScreen={!passiveSiteKey}
       >
         <SafeAreaView style={[styles.wrapper, { backgroundColor }]}>
@@ -119,6 +120,7 @@ ConfirmHcaptcha.propTypes = {
   assethost: PropTypes.string,
   imghost: PropTypes.string,
   host: PropTypes.string,
+  hasBackdrop: PropTypes.bool,
 };
 
 ConfirmHcaptcha.defaultProps = {
@@ -136,6 +138,7 @@ ConfirmHcaptcha.defaultProps = {
   assethost: undefined,
   imghost: undefined,
   host: undefined,
+  hasBackdrop: true,
 };
 
 export default ConfirmHcaptcha;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hcaptcha/react-native-hcaptcha",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hcaptcha/react-native-hcaptcha",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-native-hcaptcha",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "hCaptcha Library for React Native (both Android and iOS)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-native-hcaptcha",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "hCaptcha Library for React Native (both Android and iOS)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Problem

In the case of size=invisible the SDK still shows the modal backDrop

Solution

Add a new hasBackdrop property to handle the modal backDrop behaviour