### PR TITLE
chore: do npm publish on release event

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches: [ master ]
-    tags: [ '*' ]
+  release:
   pull_request:
   workflow_dispatch:
   schedule:
@@ -121,11 +121,11 @@ jobs:
         update_existing: true
         filename: .github/examples-issue-template.md
   release:
-    if: startsWith(github.ref, 'refs/tags') && endsWith(github.event.base_ref, 'master')
+    if: github.event_name == 'release'
     needs: [test-npm, test-yarn]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: npm release
         env:

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,18 +1,22 @@
 ### Release steps
 
-**Note:** we use [SemVer format](https://semver.org/).
+1. Decived about next version:
+
+**Note:** we use [SemVer format](https://semver.org/):
 
 MAJOR: breaking change.
 MINOR: new feature(s), backwards compatible.
 PATCH: bugfix only.
 
-Prepare a PR:
+2. Prepare a PR:
 
 - bump [`package.json's`](./package.json) version
 - run `npm i` to update `package-lock.json`
 - commit `package.json` and `package-lock.json`
-
-After merging PR and tests pass CI will do `npm publish`:
+- do tag git tag vM.M.P
+- open the PR to review
+- once the PR approved and merged create a new release https://github.com/hCaptcha/react-native-hcaptcha/releases
+- wait for CI to release new version to https://www.npmjs.com/package/@hcaptcha/react-native-hcaptcha?activeTab=versions
 
 ### Generate test app
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,6 +1,6 @@
 ### Release steps
 
-1. Decived about next version:
+1. Pick the right version number:
 
 **Note:** we use [SemVer format](https://semver.org/):
 
@@ -13,10 +13,11 @@ PATCH: bugfix only.
 - bump [`package.json's`](./package.json) version
 - run `npm i` to update `package-lock.json`
 - commit `package.json` and `package-lock.json`
-- do tag git tag vM.M.P
-- open the PR to review
-- once the PR approved and merged create a new release https://github.com/hCaptcha/react-native-hcaptcha/releases
-- wait for CI to release new version to https://www.npmjs.com/package/@hcaptcha/react-native-hcaptcha?activeTab=versions
+- open the PR for review
+- once the PR is approved and merged to master:
+ - set the tag on master matching your version: git tag `vM.M.P`
+ - draft a new release https://github.com/hCaptcha/react-native-hcaptcha/releases
+- once the release is created, CI will release the new version to https://www.npmjs.com/package/@hcaptcha/react-native-hcaptcha?activeTab=versions
 
 ### Generate test app
 


### PR DESCRIPTION
This PR improve release workflow and make it more deterministic

### How it was before

Once we did a tag CI will initiate release of the package regardless of where this tag appears on feature branch or on master. Which may be confusing if we did version bump PR with tag on it and even before the review is passed it will do release

### After this PR

The tag creation will not initiate the release process, but once you created the release in https://github.com/hCaptcha/react-native-hcaptcha/releases this will initiate the release on CI