### PR TITLE
ci: listen for published release events only

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [ master ]
   release:
+    types: [ published ]
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
We did similar for ios-sdk previusly, this will trigger ci only once and not 3 times