### PR TITLE
feat: improve UX when user is on a slow network

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,8 @@ jobs:
         # npm install -g ${{ matrix.pm }} react-native
         npm run example -- --pm ${{ matrix.pm }}
       working-directory: react-native-hcaptcha
+      env:
+        YARN_ENABLE_IMMUTABLE_INSTALLS: false
     - id: rn-version
       working-directory: react-native-hcaptcha-example
       run: |

--- a/Hcaptcha.d.ts
+++ b/Hcaptcha.d.ts
@@ -33,6 +33,10 @@ type HcaptchaProps = {
    */
   showLoading?: boolean;
   /**
+   * Allow user to cancel hcaptcha during loading by touch loader overlay
+   */
+  closableLoading?: boolean;
+  /**
    * Color of the ActivityIndicator
    */
   loadingIndicatorColor?: string;

--- a/Hcaptcha.js
+++ b/Hcaptcha.js
@@ -1,6 +1,6 @@
-import React, { useMemo, useCallback, useRef } from 'react';
+import React, { useMemo, useCallback, useRef, useState } from 'react';
 import WebView from 'react-native-webview';
-import { Linking, StyleSheet, View, ActivityIndicator } from 'react-native';
+import { Linking, StyleSheet, View, ActivityIndicator, TouchableWithoutFeedback } from 'react-native';
 import ReactNativeVersion from 'react-native/Libraries/Core/ReactNativeVersion';
 
 import md5 from './md5';
@@ -48,6 +48,7 @@ const buildHcaptchaApiUrl = (jsSrc, siteKey, hl, theme, host, sentry, endpoint, 
  * @param {*} url: base url
  * @param {*} languageCode: can be found at https://docs.hcaptcha.com/languages
  * @param {*} showLoading: loading indicator for webview till hCaptcha web content loads
+ * @param {*} closableLoading: allow user to cancel hcaptcha during loading by touch loader overlay
  * @param {*} loadingIndicatorColor: color for the ActivityIndicator
  * @param {*} backgroundColor: backgroundColor which can be injected into HTML to alter css backdrop colour
  * @param {string|object} theme: can be 'light', 'dark', 'contrast' or custom theme object
@@ -70,6 +71,7 @@ const Hcaptcha = ({
   url,
   languageCode,
   showLoading,
+  closableLoading,
   loadingIndicatorColor,
   backgroundColor,
   theme,
@@ -86,6 +88,7 @@ const Hcaptcha = ({
 }) => {
   const apiUrl = buildHcaptchaApiUrl(jsSrc, siteKey, languageCode, theme, host, sentry, endpoint, assethost, imghost, reportapi, orientation);
   const tokenTimeout = 120000;
+  const [isLoading, setIsLoading] = useState(true);
 
   if (theme && typeof theme === 'string') {
     theme = `"${theme}"`;
@@ -128,7 +131,7 @@ const Hcaptcha = ({
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("${siteKey || ''}", ${theme}, "${size || 'invisible'}"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("${siteKey || ''}", ${theme}, "${size || 'invisible'}"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -150,6 +153,7 @@ const Hcaptcha = ({
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = '${backgroundColor}';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -185,21 +189,20 @@ const Hcaptcha = ({
           };
         </script>
       </head>
-      <body style="background-color: ${backgroundColor};">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>`,
     [siteKey, backgroundColor, theme, debugInfo]
   );
 
   // This shows ActivityIndicator till webview loads hCaptcha images
-  const renderLoading = useCallback(
-    () => (
-      <View style={[styles.loadingOverlay]}>
+  const renderLoading = () => (
+    <TouchableWithoutFeedback onPress={() => closableLoading && onMessage({ nativeEvent: { data: 'cancel' } })}>
+      <View style={styles.loadingOverlay}>
         <ActivityIndicator size="large" color={loadingIndicatorColor} />
       </View>
-    ),
-    [loadingIndicatorColor]
+    </TouchableWithoutFeedback>
   );
 
   const webViewRef = useRef(null);
@@ -211,47 +214,46 @@ const Hcaptcha = ({
   };
 
   return (
-    <WebView
-      ref={webViewRef}
-      originWhitelist={['*']}
-      onShouldStartLoadWithRequest={(event) => {
-        if (event.url.slice(0, 24) === 'https://www.hcaptcha.com') {
-          Linking.openURL(event.url);
-          return false;
-        }
-        return true;
-      }}
-      mixedContentMode={'always'}
-      onMessage={(e) => {
-        e.reset = reset;
-        if (e.nativeEvent.data.length > 16) {
-          const expiredTokenTimerId = setTimeout(() => onMessage({ nativeEvent: { data: 'expired' }, reset }), tokenTimeout);
-          e.markUsed = () => clearTimeout(expiredTokenTimerId);
-        }
-        onMessage(e);
-      }}
-      javaScriptEnabled
-      injectedJavaScript={patchPostMessageJsCode}
-      automaticallyAdjustContentInsets
-      style={[{ backgroundColor: 'transparent', width: '100%' }, style]}
-      source={{
-        html: generateTheWebViewContent,
-        baseUrl: `${url}`,
-      }}
-      renderLoading={renderLoading}
-      startInLoadingState={showLoading}
-    />
+    <View style={{ flex: 1 }}>
+      <WebView
+        ref={webViewRef}
+        originWhitelist={['*']}
+        onShouldStartLoadWithRequest={(event) => {
+          if (event.url.slice(0, 24) === 'https://www.hcaptcha.com') {
+            Linking.openURL(event.url);
+            return false;
+          }
+          return true;
+        }}
+        mixedContentMode={'always'}
+        onMessage={(e) => {
+          e.reset = reset;
+          if (e.nativeEvent.data === 'open') {
+            setIsLoading(false);
+          } else if (e.nativeEvent.data.length > 16) {
+            const expiredTokenTimerId = setTimeout(() => onMessage({ nativeEvent: { data: 'expired' }, reset }), tokenTimeout);
+            e.markUsed = () => clearTimeout(expiredTokenTimerId);
+          }
+          onMessage(e);
+        }}
+        javaScriptEnabled
+        injectedJavaScript={patchPostMessageJsCode}
+        automaticallyAdjustContentInsets
+        style={[{ backgroundColor: 'transparent', width: '100%' }, style]}
+        source={{
+          html: generateTheWebViewContent,
+          baseUrl: `${url}`,
+        }}
+      />
+      {showLoading && isLoading && renderLoading()}
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
   loadingOverlay: {
-    bottom: 0,
+    ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ Otherwise, you should pass in the preferred device locale, e.g. fetched from `ge
 
 
 ### Notes
+
 - The UI defaults to the "invisible" mode of the JS SDK, i.e. no checkbox is displayed.
-- You can `import Hcaptcha from '@hcaptcha/react-native-hcaptcha/Hcaptcha';` to customize the UI yourself. 
+- You can `import Hcaptcha from '@hcaptcha/react-native-hcaptcha/Hcaptcha';` to customize the UI yourself.
+- hCaptcha loading is restricted to a 15-second timeout; an `error` will be sent via `onMessage` if it fails to load due to network issues.
 
 ## Properties
 
@@ -139,6 +141,7 @@ Otherwise, you should pass in the preferred device locale, e.g. fetched from `ge
 | onMessage | Function (see [here](https://github.com/react-native-webview/react-native-webview/blob/master/src/WebViewTypes.ts#L299)) | The callback function that runs after receiving a response, error, or when user cancels. |
 | languageCode | string | Default language for hCaptcha; overrides phone defaults. A complete list of supported languages and their codes can be found [here](https://docs.hcaptcha.com/languages/) |
 | showLoading | boolean | Whether to show a loading indicator while the hCaptcha web content loads |
+| closableLoading | boolean | Allow user to cancel hcaptcha during loading by touch loader overlay |
 | loadingIndicatorColor | string | Color of the ActivityIndicator |
 | backgroundColor | string | The background color code that will be applied to the main HTML element |
 | theme | string\|object | The theme can be 'light', 'dark', 'contrast' or a custom theme object (see Enterprise docs) |
@@ -154,7 +157,7 @@ Otherwise, you should pass in the preferred device locale, e.g. fetched from `ge
 | style _(inline component only)_ | ViewStyle (see [here](https://reactnative.dev/docs/view-style-props)) | The webview style |
 | baseUrl _(modal component only)_ | string | The url domain defined on your hCaptcha. You generally will not need to change this. |
 | passiveSiteKey _(modal component only)_ | boolean | Indicates whether the passive mode is enabled; when true, the modal won't be shown at all |
-| hasBackdrop _(modal component only)_ | boolean | Defines if the modal backdrop is shown (true by default) |
+| hasBackdrop _(modal component only)_ | boolean | Defines if the modal backdrop is shown (true by default). If `hasBackdrop=false`, `backgroundColor` will apply only after the hCaptcha visual challenge is presented. |
 | orientation | string | This specifies the "orientation" of the challenge. It can be `portrait`, `landscape`. Default: `portrait` |
 
 

--- a/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
@@ -77,7 +77,7 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <script type="text/javascript">
-          Object.entries({"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_7_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
+          Object.entries({"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_8_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
         </script>
         <script src="https://all.props/api-endpoint?render=explicit&onload=onloadCallback&host=all-props-host&hl=en&sentry=true&endpoint=https%3A%2F%2Fall.props%2Fendpoint&assethost=https%3A%2F%2Fall.props%2Fassethost&imghost=https%3A%2F%2Fall.props%2Fimghost&reportapi=https%3A%2F%2Fall.props%2Freportapi&orientation=portrait" async defer></script>
         <script type="text/javascript">

--- a/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/ConfirmHcaptcha.test.js.snap
@@ -39,9 +39,16 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
       ]
     }
   >
-    <WebView
-      automaticallyAdjustContentInsets={true}
-      injectedJavaScript="(function () {
+    <View
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <WebView
+        automaticallyAdjustContentInsets={true}
+        injectedJavaScript="(function () {
   var originalPostMessage = window.ReactNativeWebView.postMessage;
   var patchedPostMessage = function patchedPostMessage(message, targetOrigin, transfer) {
     originalPostMessage(message, targetOrigin, transfer);
@@ -51,20 +58,19 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
   };
   window.ReactNativeWebView.postMessage = patchedPostMessage;
 })();"
-      javaScriptEnabled={true}
-      mixedContentMode="always"
-      onMessage={[Function]}
-      onShouldStartLoadWithRequest={[Function]}
-      originWhitelist={
-        [
-          "*",
-        ]
-      }
-      renderLoading={[Function]}
-      source={
-        {
-          "baseUrl": "https://hcaptcha.com",
-          "html": "<!DOCTYPE html>
+        javaScriptEnabled={true}
+        mixedContentMode="always"
+        onMessage={[Function]}
+        onShouldStartLoadWithRequest={[Function]}
+        originWhitelist={
+          [
+            "*",
+          ]
+        }
+        source={
+          {
+            "baseUrl": "https://hcaptcha.com",
+            "html": "<!DOCTYPE html>
       <html>
       <head>
         <meta charset="UTF-8">
@@ -73,12 +79,12 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
         <script type="text/javascript">
           Object.entries({"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_7_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
         </script>
-        <script src="https://all.props/api-endpoint?render=explicit&onload=onloadCallback&host=all-props-host&hl=en&sentry=true&endpoint=https%3A%2F%2Fall.props%2Fendpoint&assethost=https%3A%2F%2Fall.props%2Fassethost&imghost=https%3A%2F%2Fall.props%2Fimghost&reportapi=https%3A%2F%2Fall.props%2Freportapi" async defer></script>
+        <script src="https://all.props/api-endpoint?render=explicit&onload=onloadCallback&host=all-props-host&hl=en&sentry=true&endpoint=https%3A%2F%2Fall.props%2Fendpoint&assethost=https%3A%2F%2Fall.props%2Fassethost&imghost=https%3A%2F%2Fall.props%2Fimghost&reportapi=https%3A%2F%2Fall.props%2Freportapi&orientation=portrait" async defer></script>
         <script type="text/javascript">
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("00000000-0000-0000-0000-000000000000", "light", "compact"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("00000000-0000-0000-0000-000000000000", "light", "compact"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -100,6 +106,7 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = 'rgba(0.1, 0.1, 0.1, 0.4)';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -135,23 +142,23 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with all props 1
           };
         </script>
       </head>
-      <body style="background-color: rgba(0.1, 0.1, 0.1, 0.4);">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>",
+          }
         }
-      }
-      startInLoadingState={false}
-      style={
-        [
-          {
-            "backgroundColor": "transparent",
-            "width": "100%",
-          },
-          undefined,
-        ]
-      }
-    />
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
   </RCTSafeAreaView>
 </Modal>
 `;
@@ -195,9 +202,16 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
       ]
     }
   >
-    <WebView
-      automaticallyAdjustContentInsets={true}
-      injectedJavaScript="(function () {
+    <View
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <WebView
+        automaticallyAdjustContentInsets={true}
+        injectedJavaScript="(function () {
   var originalPostMessage = window.ReactNativeWebView.postMessage;
   var patchedPostMessage = function patchedPostMessage(message, targetOrigin, transfer) {
     originalPostMessage(message, targetOrigin, transfer);
@@ -207,20 +221,19 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
   };
   window.ReactNativeWebView.postMessage = patchedPostMessage;
 })();"
-      javaScriptEnabled={true}
-      mixedContentMode="always"
-      onMessage={[Function]}
-      onShouldStartLoadWithRequest={[Function]}
-      originWhitelist={
-        [
-          "*",
-        ]
-      }
-      renderLoading={[Function]}
-      source={
-        {
-          "baseUrl": "https://hcaptcha.com",
-          "html": "<!DOCTYPE html>
+        javaScriptEnabled={true}
+        mixedContentMode="always"
+        onMessage={[Function]}
+        onShouldStartLoadWithRequest={[Function]}
+        originWhitelist={
+          [
+            "*",
+          ]
+        }
+        source={
+          {
+            "baseUrl": "https://hcaptcha.com",
+            "html": "<!DOCTYPE html>
       <html>
       <head>
         <meta charset="UTF-8">
@@ -229,12 +242,12 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
         <script type="text/javascript">
           Object.entries(["test_key"]).forEach(function (entry) { window[entry[0]] = entry[1] })
         </script>
-        <script src="https://js.hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&hl=en" async defer></script>
+        <script src="https://js.hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&hl=en&orientation=portrait" async defer></script>
         <script type="text/javascript">
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("00000000-0000-0000-0000-000000000000", "light", "invisible"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("00000000-0000-0000-0000-000000000000", "light", "invisible"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -256,6 +269,7 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = 'rgba(0, 0, 0, 0.3)';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -291,23 +305,23 @@ exports[`ConfirmHcaptcha snapshot tests renders ConfirmHcaptcha with minimum pro
           };
         </script>
       </head>
-      <body style="background-color: rgba(0, 0, 0, 0.3);">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>",
+          }
         }
-      }
-      startInLoadingState={false}
-      style={
-        [
-          {
-            "backgroundColor": "transparent",
-            "width": "100%",
-          },
-          undefined,
-        ]
-      }
-    />
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
   </RCTSafeAreaView>
 </Modal>
 `;

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -39,7 +39,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <script type="text/javascript">
-          Object.entries({"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_7_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
+          Object.entries({"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_8_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
         </script>
         <script src="https://all.props/api-endpoint?render=explicit&onload=onloadCallback&host=all-props-host&hl=fr&endpoint=https%3A%2F%2Fall.props%2Fendpoint&assethost=https%3A%2F%2Fall.props%2Fassethost&imghost=https%3A%2F%2Fall.props%2Fimghost&reportapi=https%3A%2F%2Fall.props%2Freportapi" async defer></script>
         <script type="text/javascript">
@@ -320,7 +320,7 @@ exports[`Hcaptcha snapshot tests test debug 1`] = `
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <script type="text/javascript">
-          Object.entries({"a":1,"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_7_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
+          Object.entries({"a":1,"rnver_0_0_0":true,"dep_mocked-md5":true,"sdk_1_8_2":true}).forEach(function (entry) { window[entry[0]] = entry[1] })
         </script>
         <script src="https://hcaptcha.com/1/api.js?render=explicit&onload=onloadCallback&host=00000000-0000-0000-0000-000000000000.react-native.hcaptcha.com&hl=en" async defer></script>
         <script type="text/javascript">

--- a/__tests__/__snapshots__/Hcaptcha.test.js.snap
+++ b/__tests__/__snapshots__/Hcaptcha.test.js.snap
@@ -1,9 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
-<WebView
-  automaticallyAdjustContentInsets={true}
-  injectedJavaScript="(function () {
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <WebView
+    automaticallyAdjustContentInsets={true}
+    injectedJavaScript="(function () {
   var originalPostMessage = window.ReactNativeWebView.postMessage;
   var patchedPostMessage = function patchedPostMessage(message, targetOrigin, transfer) {
     originalPostMessage(message, targetOrigin, transfer);
@@ -13,20 +20,19 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
   };
   window.ReactNativeWebView.postMessage = patchedPostMessage;
 })();"
-  javaScriptEnabled={true}
-  mixedContentMode="always"
-  onMessage={[Function]}
-  onShouldStartLoadWithRequest={[Function]}
-  originWhitelist={
-    [
-      "*",
-    ]
-  }
-  renderLoading={[Function]}
-  source={
-    {
-      "baseUrl": "https://hcaptcha.com",
-      "html": "<!DOCTYPE html>
+    javaScriptEnabled={true}
+    mixedContentMode="always"
+    onMessage={[Function]}
+    onShouldStartLoadWithRequest={[Function]}
+    originWhitelist={
+      [
+        "*",
+      ]
+    }
+    source={
+      {
+        "baseUrl": "https://hcaptcha.com",
+        "html": "<!DOCTYPE html>
       <html>
       <head>
         <meta charset="UTF-8">
@@ -40,7 +46,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("00000000-0000-0000-0000-000000000000", "contrast", "normal"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("00000000-0000-0000-0000-000000000000", "contrast", "normal"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -62,6 +68,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = 'rgba(0.1, 0.1, 0.1, 0.4)';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -97,29 +104,71 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with all props 1`] = `
           };
         </script>
       </head>
-      <body style="background-color: rgba(0.1, 0.1, 0.1, 0.4);">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>",
+      }
     }
-  }
-  startInLoadingState={true}
-  style={
-    [
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+  <View
+    accessibilityState={
       {
-        "backgroundColor": "transparent",
-        "width": "100%",
-      },
-      undefined,
-    ]
-  }
-/>
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <ActivityIndicator
+      color="#123456"
+      size="large"
+    />
+  </View>
+</View>
 `;
 
 exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
-<WebView
-  automaticallyAdjustContentInsets={true}
-  injectedJavaScript="(function () {
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <WebView
+    automaticallyAdjustContentInsets={true}
+    injectedJavaScript="(function () {
   var originalPostMessage = window.ReactNativeWebView.postMessage;
   var patchedPostMessage = function patchedPostMessage(message, targetOrigin, transfer) {
     originalPostMessage(message, targetOrigin, transfer);
@@ -129,20 +178,19 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
   };
   window.ReactNativeWebView.postMessage = patchedPostMessage;
 })();"
-  javaScriptEnabled={true}
-  mixedContentMode="always"
-  onMessage={[Function]}
-  onShouldStartLoadWithRequest={[Function]}
-  originWhitelist={
-    [
-      "*",
-    ]
-  }
-  renderLoading={[Function]}
-  source={
-    {
-      "baseUrl": "https://hcaptcha.com",
-      "html": "<!DOCTYPE html>
+    javaScriptEnabled={true}
+    mixedContentMode="always"
+    onMessage={[Function]}
+    onShouldStartLoadWithRequest={[Function]}
+    originWhitelist={
+      [
+        "*",
+      ]
+    }
+    source={
+      {
+        "baseUrl": "https://hcaptcha.com",
+        "html": "<!DOCTYPE html>
       <html>
       <head>
         <meta charset="UTF-8">
@@ -156,7 +204,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("", undefined, "invisible"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("", undefined, "invisible"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -178,6 +226,7 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = 'undefined';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -213,28 +262,36 @@ exports[`Hcaptcha snapshot tests renders Hcaptcha with minimum props 1`] = `
           };
         </script>
       </head>
-      <body style="background-color: undefined;">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>",
+      }
     }
-  }
-  style={
-    [
-      {
-        "backgroundColor": "transparent",
-        "width": "100%",
-      },
-      undefined,
-    ]
-  }
-/>
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
 `;
 
 exports[`Hcaptcha snapshot tests test debug 1`] = `
-<WebView
-  automaticallyAdjustContentInsets={true}
-  injectedJavaScript="(function () {
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <WebView
+    automaticallyAdjustContentInsets={true}
+    injectedJavaScript="(function () {
   var originalPostMessage = window.ReactNativeWebView.postMessage;
   var patchedPostMessage = function patchedPostMessage(message, targetOrigin, transfer) {
     originalPostMessage(message, targetOrigin, transfer);
@@ -244,20 +301,19 @@ exports[`Hcaptcha snapshot tests test debug 1`] = `
   };
   window.ReactNativeWebView.postMessage = patchedPostMessage;
 })();"
-  javaScriptEnabled={true}
-  mixedContentMode="always"
-  onMessage={[Function]}
-  onShouldStartLoadWithRequest={[Function]}
-  originWhitelist={
-    [
-      "*",
-    ]
-  }
-  renderLoading={[Function]}
-  source={
-    {
-      "baseUrl": "https://hcaptcha.com",
-      "html": "<!DOCTYPE html>
+    javaScriptEnabled={true}
+    mixedContentMode="always"
+    onMessage={[Function]}
+    onShouldStartLoadWithRequest={[Function]}
+    originWhitelist={
+      [
+        "*",
+      ]
+    }
+    source={
+      {
+        "baseUrl": "https://hcaptcha.com",
+        "html": "<!DOCTYPE html>
       <html>
       <head>
         <meta charset="UTF-8">
@@ -271,7 +327,7 @@ exports[`Hcaptcha snapshot tests test debug 1`] = `
           var onloadCallback = function() {
             try {
               console.log("challenge onload starting");
-              hcaptcha.render("submit", getRenderConfig("00000000-0000-0000-0000-000000000000", undefined, "invisible"));
+              hcaptcha.render("hcaptcha-container", getRenderConfig("00000000-0000-0000-0000-000000000000", undefined, "invisible"));
               // have loaded by this point; render is sync.
               console.log("challenge render complete");
             } catch (e) {
@@ -293,6 +349,7 @@ exports[`Hcaptcha snapshot tests test debug 1`] = `
             window.ReactNativeWebView.postMessage("cancel");
           };
           var onOpen = function() {
+            document.body.style.backgroundColor = 'undefined';
             window.ReactNativeWebView.postMessage("open");
             console.log("challenge opened");
           };
@@ -328,20 +385,21 @@ exports[`Hcaptcha snapshot tests test debug 1`] = `
           };
         </script>
       </head>
-      <body style="background-color: undefined;">
-        <div id="submit"></div>
+      <body>
+        <div id="hcaptcha-container"></div>
       </body>
       </html>",
+      }
     }
-  }
-  style={
-    [
-      {
-        "backgroundColor": "transparent",
-        "width": "100%",
-      },
-      undefined,
-    ]
-  }
-/>
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
 `;

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ class ConfirmHcaptcha extends PureComponent {
       orientation,
       onMessage,
       showLoading,
+      closableLoading,
       backgroundColor,
       loadingIndicatorColor,
       theme,
@@ -61,7 +62,7 @@ class ConfirmHcaptcha extends PureComponent {
         hasBackdrop={!passiveSiteKey && hasBackdrop}
         coverScreen={!passiveSiteKey}
       >
-        <SafeAreaView style={[styles.wrapper, { backgroundColor }]}>
+        <SafeAreaView style={[styles.wrapper, hasBackdrop ? { backgroundColor } : {}]}>
           <Hcaptcha
             url={baseUrl}
             size={size}
@@ -69,6 +70,7 @@ class ConfirmHcaptcha extends PureComponent {
             onMessage={onMessage}
             languageCode={languageCode}
             showLoading={showLoading}
+            closableLoading={closableLoading}
             loadingIndicatorColor={loadingIndicatorColor}
             backgroundColor={backgroundColor}
             theme={theme}
@@ -80,6 +82,7 @@ class ConfirmHcaptcha extends PureComponent {
             assethost={assethost}
             imghost={imghost}
             host={host}
+            orientation={orientation}
             debug={debug}
           />
         </SafeAreaView>
@@ -114,6 +117,7 @@ ConfirmHcaptcha.propTypes = {
   orientation: PropTypes.string,
   backgroundColor: PropTypes.string,
   showLoading: PropTypes.bool,
+  closableLoading: PropTypes.bool,
   loadingIndicatorColor: PropTypes.string,
   theme: PropTypes.string,
   rqdata: PropTypes.string,
@@ -132,6 +136,7 @@ ConfirmHcaptcha.defaultProps = {
   size: 'invisible',
   passiveSiteKey: false,
   showLoading: false,
+  closableLoading: false,
   orientation: 'portrait',
   backgroundColor: 'rgba(0, 0, 0, 0.3)',
   loadingIndicatorColor: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hcaptcha/react-native-hcaptcha",
-  "version": "1.7.2",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hcaptcha/react-native-hcaptcha",
-      "version": "1.7.2",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/react-native-hcaptcha",
-  "version": "1.7.2",
+  "version": "1.8.2",
   "description": "hCaptcha Library for React Native (both Android and iOS)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Related issue #64 

- add `closableLoading` property to allow user to tap to cancel hCaptcha during loading
- `hasBackdrop=false` now affects `backgroundColor` and no background will be shown till hCaptcha is loaded
- emit `'error'` if hCaptha wasn't load in 15s

closes #65 