### PR TITLE
chore: workflow cleanup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,8 +9,14 @@ on:
   schedule:
     - cron: '0 0 * * 0' # https://crontab.guru/every-week
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -26,6 +32,10 @@ jobs:
         key: reassure-baseline-${{ github.sha }}
 
   performance:
+    permissions:
+      contents: read
+      actions: read
+      issues: write
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -57,6 +67,8 @@ jobs:
 
   test:
     needs: build
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     outputs:
       rn-version: ${{ steps.rn-version.outputs.value }}
@@ -107,9 +119,12 @@ jobs:
       working-directory: react-native-hcaptcha-example
 
   create-an-issue:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     needs: test
-    if: always() && github.event == 'schedule' && needs.test.result == 'failure'
+    if: always() && github.event_name == 'schedule' && needs.test.result == 'failure'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: |
@@ -126,6 +141,8 @@ jobs:
         filename: .github/examples-issue-template.md
 
   release:
+    permissions:
+      contents: read
     if: github.event_name == 'release'
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
  - Set default GITHUB_TOKEN scope to contents: read in .github/workflows/ tests.yaml and added job-level permissions to limit privileges: build now only has contents + actions: write for cache save, performance only contents/actions: read/issues: write for PR comments, test only contents: read, create-an-issue only contents/issues: write, release only contents: read.
  - Corrected the scheduled issue-creation guard to github.event_name == 'schedule' so it can’t accidentally run outside the intended trigger.
  - Actions remain commit-pinned; no unpinned third-party actions found.